### PR TITLE
fix: 修复当线程退出的时候,使用splice从workerQueue中删除worker返回的是数组不是对象

### DIFF
--- a/src/threadPool.js
+++ b/src/threadPool.js
@@ -131,7 +131,8 @@ class ThreadPool {
             const position = this.workerQueue.findIndex((thread) => {
                 return thread.threadId === threadId;
             });
-            const exitedThread = this.workerQueue.splice(position, 1);
+            const exitedThreadArray = this.workerQueue.splice(position, 1);
+            const exitedThread = exitedThreadArray[0]
             // 退出时状态是BUSY说明还在处理任务（非正常退出）
             this.totalWork -= exitedThread.state === THREAD_STATE.BUSY ? 1 : 0;
         });


### PR DESCRIPTION
splice 返回值 由被删除的元素组成的一个数组。如果只删除了一个元素，则返回只包含一个元素的数组。如果没有删除元素，则返回空数组。